### PR TITLE
updating resource sequence to cover dcb-oim-dss also

### DIFF
--- a/resource-sequence.puml
+++ b/resource-sequence.puml
@@ -1,18 +1,20 @@
 @startuml
 participant "Resource operator" as RO
+participant "Vehicle operator" as op
 participant "Resource\nInformation\nService (RIS)" as RIS
 participant "Discovery &\nSynchronization\nService (DSS)" as DSS
-participant "DCB" as DCB
+participant "Demand\nCapacity\nBalancing\n(DCB)" as DCB
 participant "DCB2" as DCB2
-participant "OIM" as OIM
-participant "OIM2" as OIM2
+participant "Operational\nIntent\nManagement\n(OIM)" as OIM
+participant "Conformance\nMonitoring\n(CM)" as CM
+participant "CM2" as CM2
 
 
 ==DCB subscribe to resources==
-DCB -> DSS: PUT /DSS/v1/subscriptions/resource-subscription/
+DCB -> DSS: PUT /DSS/v1/subscriptions/resource-subscription/{subscriptionid}
 DCB <-- DSS: resource references (empty)
 
-DCB -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/
+DCB -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/{subscriptionid}
 DCB <-- DSS: operation references (empty)
 
 note over DCB
@@ -70,14 +72,25 @@ loop For each resource subscriber
     RIS -> DCB: POST /v1/resource-details/{resource-id}/definition (includes OVN)
 end
 
+
+== OIM received request from operator and submits an operation to the DSS in proposed state == 
+op -> OIM: Op Request
+OIM -> DSS: PUT /dss/v1/operational_intent_references/{entityId}  (Proposed state)
+note over DSS
+Does not check any OVNs here.
+All operation intents accepted.
+end note
+OIM <-- DSS: subscribers to notify
+loop For all subscribers
+    OIM -> DCB: POST /dcb/v1/operational_intents (includes OVN)
+    DCB -> DCB: Adjust demand/capacity values
+    OIM -> DCB2:  POST /dcb/v1/operational_intents (includes OVN)
+    DCB2 -> DCB2: Adjust demand/capacity values
+end
+
 == A new subscriber joins == 
-
-DCB2 -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/
-DCB2 <-- DSS: operation references (empty)
-
 DCB2 -> DSS: PUT /DSS/v1/subscriptions/resource-subscription/
 DCB2 <-- DSS: resource references
-
 loop For each resource reference received
     note over DCB2
     Get all resource details.
@@ -85,38 +98,43 @@ loop For each resource reference received
     DCB2 -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
     DCB2 <-- RIS: resource details (everything)
 end
-
-
-== OIM2 submits an operation to the DSS == 
-OIM2 -> DSS: PUT /dss/v1/operational_intent_references/{entityId}  (Proposed state)
-note over DSS
-Does not check any OVNs here.
-All operation intents accepted.
-end note
-OIM2 <-- DSS: subscribers to notify
-loop For all subscribers
-    ' OIM2 -> RIS: /psu/v1/operational_intents (includes OVN)
-    OIM2 -> DCB: /psu/v1/operational_intents (includes OVN)
-    DCB -> DCB: Adjust demand/capacity values
-    OIM2 -> DCB2:  /psu/v1/operational_intents (includes OVN)
-    DCB2 -> DCB2: Adjust demand/capacity values
+DCB2 -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/
+DCB2 <-- DSS: operation references
+loop For each operation reference received
+    note over DCB2
+    Get all resource details.
+    end note
+    DCB2 -> OIM: GET /v1/operation_details/{operation-id} (includes OVN)
+    DCB2 <-- OIM: operation details (everything)
 end
 
-== OIM wants to transition operation to Accepted state (OVNs required) ==
-' OIM -> DCB: Get available resources
-' OIM <-- DCB: Return all resources, OVNs, avaialble time ranges
 
-
-OIM -> DCB: Submit proposed intent
+== OIM does DCB check and transitions operation to Accepted state (OVNs required) ==
+OIM -> DCB: POST /dcb/v1/imbalance/intent
 OIM <-- DCB: Yes/no, OVNs for all resources, available time ranges
 
-OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Accepted)
-DSS -> DSS: Confirms OVNs are correct
-OIM <-- DSS: operation intent reference with subscribers
-loop For all subscribers
-    OIM -> DCB2: PUT /psu/v1/operational_intents
-    OIM -> DCB: PUT /psu/v1/operational_intents
+alt If imbalance detected
+    note over OIM: Do not update the operation
+else If no imbalance detected
+    OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Accepted)
+    DSS -> DSS: Confirms OVNs are correct
+    OIM <-- DSS: operation intent reference with subscribers
+    loop For all subscribers
+        OIM -> DCB2: POST /dcb/v1/operational_intents
+        OIM -> DCB: POST /dcb/v1/operational_intents
+    end
 end
 
+==Telemetry Sharing==
+OIM -> CM: POST /cm/v1/operational_intents
+op -> CM: Telemetry
+alt If Operation in Activated, DCB-Noncompliant or Contingent States
+    loop 
+        CM -> CM2: GET /cm/v1/operational_intents/{entityid}/telemetry        
+    end
+else If operation ended or cancelled
+    note over CM: Stop retrieving telemetry
+end 
+CM2 -> CM: GET /cm/v1/operational_intents/{entityid}/telemetry
 
 @enduml

--- a/resource-sequence.puml
+++ b/resource-sequence.puml
@@ -84,12 +84,10 @@ OIM <-- DSS: subscribers to notify
 loop For all subscribers
     OIM -> DCB: POST /dcb/v1/operational_intents (includes OVN)
     DCB -> DCB: Adjust demand/capacity values
-    OIM -> DCB2:  POST /dcb/v1/operational_intents (includes OVN)
-    DCB2 -> DCB2: Adjust demand/capacity values
 end
 
 == A new subscriber joins == 
-DCB2 -> DSS: PUT /DSS/v1/subscriptions/resource-subscription/
+DCB2 -> DSS: PUT /dss/v1/subscriptions/resource-subscription/
 DCB2 <-- DSS: resource references
 loop For each resource reference received
     note over DCB2
@@ -98,13 +96,13 @@ loop For each resource reference received
     DCB2 -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
     DCB2 <-- RIS: resource details (everything)
 end
-DCB2 -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/
+DCB2 -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
 DCB2 <-- DSS: operation references
 loop For each operation reference received
     note over DCB2
     Get all resource details.
     end note
-    DCB2 -> OIM: GET /v1/operation_details/{operation-id} (includes OVN)
+    DCB2 -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
     DCB2 <-- OIM: operation details (everything)
 end
 
@@ -125,10 +123,35 @@ else If no imbalance detected
     end
 end
 
-==Telemetry Sharing==
-OIM -> CM: POST /cm/v1/operational_intents
+==Conformance Monitoring==
+OIM -> CM: POST /cm/v1/operational_intents ????
+' CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
+' CM <-- DSS: operation references
+' loop For each operation reference received
+'     note over CM
+'     Get all resource details.
+'     end note
+'     CM -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
+'     CM <-- OIM: operation details (everything)
+' end
 op -> CM: Telemetry
-alt If Operation in Activated, DCB-Noncompliant or Contingent States
+loop
+    CM -> CM: Conformance monitoring
+    alt If operation in conformance
+        note over CM: Do nothing
+    else If operation not in conformance
+        CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant) ?????
+        OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant)
+        OIM <-- DSS: operation intent reference with subscribers
+        loop For all subscribers
+            OIM -> DCB2: POST /dcb/v1/operational_intents
+            OIM -> DCB: POST /dcb/v1/operational_intents
+        end
+    end
+end
+
+==Telemetry Sharing==
+alt If operation in Activated, DCB-Noncompliant or Contingent States
     loop 
         CM -> CM2: GET /cm/v1/operational_intents/{entityid}/telemetry        
     end

--- a/sequence.puml
+++ b/sequence.puml
@@ -100,7 +100,7 @@ DCB2 -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
 DCB2 <-- DSS: operation references
 loop For each operation reference received
     note over DCB2
-    Get all resource details.
+    Get all operation details.
     end note
     DCB2 -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
     DCB2 <-- OIM: operation details (everything)
@@ -124,23 +124,48 @@ else If no imbalance detected
 end
 
 ==Conformance Monitoring==
-OIM -> CM: POST /cm/v1/operational_intents ????
-' CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
-' CM <-- DSS: operation references
-' loop For each operation reference received
-'     note over CM
-'     Get all resource details.
-'     end note
-'     CM -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
-'     CM <-- OIM: operation details (everything)
-' end
-op -> CM: Telemetry
+OIM -> CM: POST /cm/v1/operational_intents
+'CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
+'CM <-- DSS: operation references
+loop For each operation reference received
+'    note over CM
+'    Get all operation details.
+'    end note
+'    CM -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
+'    CM <-- OIM: operation details (everything)
+    note over CM
+    Get all resource details for the operation.
+    end note
+    CM -> DSS: PUT /dss/v1/subscriptions/resource-subscription/
+    CM <-- DSS: resource references
+    loop For each resource reference received
+        note over CM
+        Get all resource details.
+        end note
+        CM -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
+        CM <-- RIS: resource details (everything)
+    end
+end
+op -> CM: Position reports
+alt If position reports for operations in Accepted state
+    loop For all operations in Accepted state with position reports
+        CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
+        OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
+        OIM <-- DSS: operation intent reference with subscribers
+        loop For all subscribers
+            OIM -> DCB2: POST /dcb/v1/operational_intents
+            OIM -> DCB: POST /dcb/v1/operational_intents
+        end
+    end
+else If no position reports for operations in Accepted state
+    note over CM: Do nothing
+end
 loop
     CM -> CM: Conformance monitoring
     alt If operation in conformance
         note over CM: Do nothing
     else If operation not in conformance
-        CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant) ?????
+        CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant)
         OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant)
         OIM <-- DSS: operation intent reference with subscribers
         loop For all subscribers
@@ -150,7 +175,7 @@ loop
     end
 end
 
-==Telemetry Sharing==
+==Position Sharing==
 alt If operation in Activated, DCB-Noncompliant or Contingent States
     loop 
         CM -> CM2: GET /cm/v1/operational_intents/{entityid}/telemetry        
@@ -159,5 +184,4 @@ else If operation ended or cancelled
     note over CM: Stop retrieving telemetry
 end 
 CM2 -> CM: GET /cm/v1/operational_intents/{entityid}/telemetry
-
 @enduml

--- a/sequence.puml
+++ b/sequence.puml
@@ -133,20 +133,15 @@ OIM -> CM: POST /cm/v1/operational_intents
 'CM <-- DSS: operation references
 
 op -> CM: Position reports
-alt If position reports for operations in Accepted state
-    loop For all operations in Accepted state with position reports
-        CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
-        OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
-        OIM <-- DSS: operation intent reference with subscribers
-        loop For all subscribers
-            OIM -> DCB2: POST /dcb/v1/operational_intents
-            OIM -> DCB: POST /dcb/v1/operational_intents
-        end
+alt If position reports for operation in Accepted state
+    CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
+    OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
+    OIM <-- DSS: operation intent reference with subscribers
+    loop For all subscribers
+        OIM -> DCB2: POST /dcb/v1/operational_intents
+        OIM -> DCB: POST /dcb/v1/operational_intents
     end
-else If no position reports for operations in Accepted state
-    note over CM: Do nothing
-end
-loop
+else If position reports for operation in Activated state
     CM -> CM: Conformance monitoring
     alt If operation in conformance
         note over CM: Do nothing

--- a/sequence.puml
+++ b/sequence.puml
@@ -1,12 +1,12 @@
 @startuml
 participant "Resource operator" as RO
 participant "Vehicle operator" as op
-participant "Resource\nInformation\nService (RIS)" as RIS
-participant "Discovery &\nSynchronization\nService (DSS)" as DSS
-participant "Demand\nCapacity\nBalancing\n(DCB)" as DCB
+participant "Resource Information Service (RIS)" as RIS
+participant "Discovery & Synchronization Service (DSS)" as DSS
+participant "Demand Capacity Balancing (DCB)" as DCB
 participant "DCB2" as DCB2
-participant "Operational\nIntent\nManagement\n(OIM)" as OIM
-participant "Conformance\nMonitoring\n(CM)" as CM
+participant "Operational Intent Management (OIM)" as OIM
+participant "Conformance Monitoring (CM)" as CM
 participant "CM2" as CM2
 
 ==DCB subscribe to resources==
@@ -17,30 +17,25 @@ DCB -> DSS: PUT /DSS/v1/subscriptions/operation-subscription/{subscriptionid}
 DCB <-- DSS: operation references (empty)
 
 note over DCB
-No resources exist. 
-Nothing to do yet. 
+No resources exist. Nothing to do yet. 
 end note
 
 ==Make resources discoverable==
 note over RO
-Resource is originally
-defined here.
+Resource is originally defined here.
 end note 
 RO -> RIS: Submit initial resource definition, capacity, and status
 RIS -> DSS: PUT /DSS/v1/resource-reference/
 note over DSS
-Resource reference creation
-creates an implicit self-subscription
-for any changes needed to the resource
-due to OIM flight intents.
+Resource reference creation creates an implicit self-subscription
+for any changes needed to the resource due to OIM flight intents.
 end note
 DSS --> RIS: subscribers, resource-reference including subscription id
 loop For each resource subscriber
     DCB <-- RIS: POST /v1/resource-details/{resource-id}  (everything, includes OVN)
 end
 note over DCB
-Assumption: ResourceDetails contains definition,
-status, and capacity. 
+Assumption: ResourceDetails contains definition, status and capacity. 
 end note
 
 == Resource capacity, status or definition is adjusted ==
@@ -69,8 +64,7 @@ end
 op -> OIM: Op Request
 OIM -> DSS: PUT /dss/v1/operational_intent_references/{entityId}  (Proposed state)
 note over DSS
-Does not check any OVNs here.
-All operation intents accepted.
+Does not check any OVNs here. All operation intents accepted.
 end note
 OIM <-- DSS: subscribers to notify
 loop For all subscribers
@@ -120,8 +114,6 @@ CM <-- DSS: resource references
 CM -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
 CM <-- RIS: resource details (everything)
 OIM -> CM: POST /cm/v1/operational_intents
-'CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
-'CM <-- DSS: operation references
 
 op -> CM: Vehicle position
 alt If vehicle position for operation in Accepted state

--- a/sequence.puml
+++ b/sequence.puml
@@ -124,28 +124,14 @@ else If no imbalance detected
 end
 
 ==Conformance Monitoring==
+CM -> DSS: PUT /dss/v1/subscriptions/resource-subscription/
+CM <-- DSS: resource references
+CM -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
+CM <-- RIS: resource details (everything)
 OIM -> CM: POST /cm/v1/operational_intents
 'CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
 'CM <-- DSS: operation references
-loop For each operation reference received
-'    note over CM
-'    Get all operation details.
-'    end note
-'    CM -> OIM: GET /v1/operation_intents/{operation-id} (includes OVN)
-'    CM <-- OIM: operation details (everything)
-    note over CM
-    Get all resource details for the operation.
-    end note
-    CM -> DSS: PUT /dss/v1/subscriptions/resource-subscription/
-    CM <-- DSS: resource references
-    loop For each resource reference received
-        note over CM
-        Get all resource details.
-        end note
-        CM -> RIS: GET /v1/resource-details/{resource-id} (includes OVN)
-        CM <-- RIS: resource details (everything)
-    end
-end
+
 op -> CM: Position reports
 alt If position reports for operations in Accepted state
     loop For all operations in Accepted state with position reports

--- a/sequence.puml
+++ b/sequence.puml
@@ -9,7 +9,6 @@ participant "Operational\nIntent\nManagement\n(OIM)" as OIM
 participant "Conformance\nMonitoring\n(CM)" as CM
 participant "CM2" as CM2
 
-
 ==DCB subscribe to resources==
 DCB -> DSS: PUT /DSS/v1/subscriptions/resource-subscription/{subscriptionid}
 DCB <-- DSS: resource references (empty)
@@ -44,19 +43,14 @@ Assumption: ResourceDetails contains definition,
 status, and capacity. 
 end note
 
-== Resource capacity is adjusted ==
+== Resource capacity, status or definition is adjusted ==
 RO -> RIS: Update resource capacity
 RIS -> DSS: PUT /DSS/v1/resource-reference/{resource-id}
 RIS <-- DSS: subscribers
 loop For each resource subscriber
     RIS -> DCB: POST /v1/resource-details/{resource-id}/capacity (includes OVN)
-    note over DCB #pink
-    Separate updates for capacity,
-    status, and definition?
-    end note
 end
 
-== Resource status is adjusted ==
 RO -> RIS: Update resource status
 RIS -> DSS: PUT /DSS/v1/resource-reference/{resource-id}
 RIS <-- DSS: subscribers
@@ -64,7 +58,6 @@ loop For each resource subscriber
     RIS -> DCB: POST /v1/resource-details/{resource-id}/status (includes OVN)
 end
 
-== Resource definition is adjusted ==
 RO -> RIS: Update resource definition
 RIS -> DSS: PUT /DSS/v1/resource-reference/{resource-id}
 RIS <-- DSS: subscribers
@@ -72,8 +65,7 @@ loop For each resource subscriber
     RIS -> DCB: POST /v1/resource-details/{resource-id}/definition (includes OVN)
 end
 
-
-== OIM received request from operator and submits an operation to the DSS in proposed state == 
+== OIM receives request from operator and submits an operation to the DSS in proposed state == 
 op -> OIM: Op Request
 OIM -> DSS: PUT /dss/v1/operational_intent_references/{entityId}  (Proposed state)
 note over DSS
@@ -106,7 +98,6 @@ loop For each operation reference received
     DCB2 <-- OIM: operation details (everything)
 end
 
-
 == OIM does DCB check and transitions operation to Accepted state (OVNs required) ==
 OIM -> DCB: POST /dcb/v1/imbalance/intent
 OIM <-- DCB: Yes/no, OVNs for all resources, available time ranges
@@ -132,16 +123,25 @@ OIM -> CM: POST /cm/v1/operational_intents
 'CM -> DSS: PUT /dss/v1/subscriptions/operation-subscription/
 'CM <-- DSS: operation references
 
-op -> CM: Position reports
-alt If position reports for operation in Accepted state
+op -> CM: Vehicle position
+alt If vehicle position for operation in Accepted state
     CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
-    OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
-    OIM <-- DSS: operation intent reference with subscribers
-    loop For all subscribers
-        OIM -> DCB2: POST /dcb/v1/operational_intents
-        OIM -> DCB: POST /dcb/v1/operational_intents
-    end
-else If position reports for operation in Activated state
+    note over OIM: OIM does a DCB check
+    OIM -> DCB: POST /dcb/v1/imbalance/intent
+    OIM <-- DCB: Yes/no, OVNs for all resources, available time ranges
+
+    alt If imbalance detected
+        note over OIM: Do not update the operation
+    else If no imbalance detected
+        OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = Activated)
+        DSS -> DSS: Confirms OVNs are correct
+        OIM <-- DSS: operation intent reference with subscribers
+        loop For all subscribers
+            OIM -> DCB2: POST /dcb/v1/operational_intents
+            OIM -> DCB: POST /dcb/v1/operational_intents
+        end
+    end 
+else If vehicle position for operation in Activated state
     CM -> CM: Conformance monitoring
     alt If operation in conformance
         note over CM: Do nothing
@@ -156,13 +156,35 @@ else If position reports for operation in Activated state
     end
 end
 
-==Position Sharing==
-alt If operation in Activated, DCB-Noncompliant or Contingent States
-    loop 
-        CM -> CM2: GET /cm/v1/operational_intents/{entityid}/telemetry        
+==Conformance monitoring when resource capacity changes==
+RO -> RIS: Update resource capacity
+RIS -> DSS: PUT /DSS/v1/resource-reference/{resource-id}
+RIS <-- DSS: subscribers
+loop For each resource subscriber
+    RIS -> DCB: POST /v1/resource-details/{resource-id}/capacity
+    DCB -> DCB: Adjust demand/capacity values
+    RIS -> DCB2: POST /v1/resource-details/{resource-id}/capacity
+    RIS -> CM: POST /v1/resource-details/{resource-id}/capacity
+end
+note over CM: DCB check
+CM -> DCB: POST /dcb/v1/imbalance/intent
+CM <-- DCB: Yes/no, OVNs for all resources, available time ranges
+
+alt If imbalance detected
+    CM -> OIM: POST /oim/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant)
+    OIM -> DSS: PUT /dss/v1/operation_intent_references/{entityId}/{ovn}\n(state = DCB-Noncompliant)
+    OIM <-- DSS: operation intent reference with subscribers
+    loop For all subscribers
+        OIM -> DCB2: POST /dcb/v1/operational_intents
+        OIM -> DCB: POST /dcb/v1/operational_intents
     end
-else If operation ended or cancelled
-    note over CM: Stop retrieving telemetry
+else If no imbalance detected
+    note over CM: do nothing
 end 
-CM2 -> CM: GET /cm/v1/operational_intents/{entityid}/telemetry
+
+==Position Sharing==
+loop 
+    CM2 -> CM: GET /cm/v1/operational_intents/{entityid}/telemetry
+    CM2 <-- CM: telemetry
+end
 @enduml


### PR DESCRIPTION
This PR adds elements from the DCB-OIM-DSS sequence so that it covers all information flows. Goal is to deprecate the dcb-oim-dss sequence and have all flows covered in a single sequence diagram.

Also adjust the order slightly, with the new subscriber coming after an operation is added to the DSS in proposed state.