### PR TITLE
changes to spell out TCP and explain use case for subscription query

### DIFF
--- a/DSS/astm-uam-psu-dss-0.0.0.yaml
+++ b/DSS/astm-uam-psu-dss-0.0.0.yaml
@@ -1102,6 +1102,7 @@ paths:
       summary: Query all subscriptions in the specified area/volume from the DSS.
       description: |-
         Query subscriptions intersecting an area of interest.  Subscription notifications are only triggered by (and contain full information of) changes to, creation of, or deletion of, Entities referenced by or stored in the DSS; they do not involve any data transfer (such as remote ID telemetry updates) apart from Entity information.
+        A query of subscriptions may be needed to validate what subscriptions a subscriber has in place, or to identify existing subscription after a loss of data on the part of the subscriber.
         Note that this parameter is a JSON object (in the 'request-body'). Note that either or both of the 'altitude' and 'time' values may be omitted from this parameter.
         Only subscriptions belonging to the caller are returned.  This endpoint would be used if a USS lost track of subscriptions they had created and/or wanted to resolve an error indicating that they had too many existing subscriptions in an area.
       operationId: querySubscriptions

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -1213,9 +1213,9 @@ components:
           enum:
           - TOP_OF_CLIMB
           - TOP_OF_DESCENT
-          - TCP_VERTICAL
-          - TCP_SPEED
-          - TCP_LATERAL
+          - TRAJECTORY_CHANGE_POINT_VERTICAL
+          - TRAJECTORY_CHANGE_POINT_SPEED
+          - TRAJECTORY_CHANGE_POINT_LATERAL
           - WHEELS_OFF
           - WHEELS_ON
           - AIRPORT_REFERENCE_LOCATION


### PR DESCRIPTION
- Spell out TCP to TRAJECTORY_CHANGE_POINT
- Add a sentence explaining use case for /dss/v1/subscriptions/query: