### PR TITLE
Add log_sets endpoint and PSULogSet following shared-components refactor

### DIFF
--- a/CM/astm-uam-psu-cm-0.0.0.yaml
+++ b/CM/astm-uam-psu-cm-0.0.0.yaml
@@ -324,16 +324,4 @@ components:
       description: |-
         Parameters of a message informing of detailed information for an operational intent that requirements conformance monitoring.
         Pushed (by an OIM role) directly to CM roles when an operational intent is authorized, or changes are made.
-    PutOperationalIntentTelemetry:
-      required:
-      - operational_intent_id
-      - telemetry
-      type: object
-      properties:
-        operational_intent_id:
-          description: ID of the operational intent which the vehicle reporting telemetry is flying.
-          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
-        telemetry:
-          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/VehicleTelemetry'
-      description: provide detailed information on the position of an aircraft associated with an operational intent.
       

--- a/DSS/astm-uam-psu-dss-0.0.0.yaml
+++ b/DSS/astm-uam-psu-dss-0.0.0.yaml
@@ -2264,40 +2264,6 @@ components:
           items:
             $ref: '#/components/schemas/SubscriberToNotify'
           default: []
-    PlanningRecord:
-      required:
-      - ovns
-      - time
-      type: object
-      properties:
-        time:
-          description: Time that this planning event occurred
-          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
-        ovns:
-          type: array
-          description: OVNs the planning USS was aware of when it was planning the operational intent
-          items:
-            $ref: '#/components/schemas/EntityOVN'
-          default: []
-        missing_operational_intents:
-          type: array
-          description: List of missing operational intents (for planning attempts that were denied by the DSS with code 409)
-          items:
-            $ref: '#/components/schemas/EntityID'
-          default: []
-        missing_resources:
-          type: array
-          description: List of missing resources (for planning attempts that were denied by the DSS with code 409)
-          items:
-            $ref: '#/components/schemas/EntityID'
-          default: []          
-        operational_intent_id:
-          description: ID of the operational intent being planned
-          $ref: '#/components/schemas/EntityID'
-        problem:
-          type: string
-          description: A free text description of the problem(s) encountered during this planning attempt.
-      description: A record of a single attempt to (successfully or unsuccessfully) create or modify an operational intent.
     Authority:
       type: object
       properties:

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -301,7 +301,36 @@ paths:
       security:
       - Authority:
         - utm.strategic_coordination
-
+  /oim/v1/log_sets/{log_set_id}:
+    summary: General summary
+    parameters:
+    - name: log_set_id
+      description: >-
+        USS-defined identifier for a set of log entries.  For instance, this
+        ID may refer to all logs associated with a particular reportable
+        incident, or over a time range for the purpose of metric computation.
+      schema:
+        type: string
+      in: path
+      required: true
+      example: com.example.incident.20200107.v4
+    get:
+      tags:
+      - Logging
+      summary: Get PSU logs
+      operationId: getPSULogSet
+      description: >-
+        A PSU will not usually implement this endpoint directly, but rather will
+        be capable of exporting log data in a format equivalent to the response
+        format of this pseudo-endpoint according to the requirements of the
+        standard.
+      responses:
+        '200':
+          description: Log data successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PSULogSet'
 components:
   securitySchemes:
     $ref: '../shared-components/schemas.yaml#/components/securitySchemes'
@@ -539,4 +568,182 @@ components:
           - Takeoff
           - Nonconforming
           - Reconforming
-      
+    PSULogSet:
+      type: object
+      description: >-
+        The set of log data fulfilling this standard's Logging requirements.
+      properties:
+        messages:
+          description: >-
+            Outgoing messages sent to other PSUs and the DSS, and incoming
+            messages received from other PSUs, including instances where an
+            expected response to a request is not received.
+          type: array
+          items:
+            $ref: '../shared-components/schemas.yaml#/components/schemas/ExchangeRecord'
+          default: [ ]
+        operator_notifications:
+          description: >-
+            Instances of operator notifications as specifically required within
+            this standard.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserNotificationRecord'
+          default: [ ]
+        operator_inputs:
+          description: >-
+            Instances of operator input as specifically required within this
+            standard.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserInputRecord'
+          default: [ ]
+        operator_associations:
+          description: >-
+            For a PSU that manages operational intents, associations of an
+            operator with operational intents that transitioned to the Accepted
+            state.
+          type: array
+          items:
+            $ref: '#/components/schemas/OperatorAssociation'
+          default: [ ]
+        planning_attempts:
+          description: >-
+            For a PSU that manages operational intents, instances where an
+            operational intent could not be planned or replanned due to
+            conflicts with other operational intents or constraints.
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanningRecord'
+          default: [ ]
+        operational_intent_positions:
+          description: >-
+            For a PSU performing conformance monitoring, all position data used
+            for conformance monitoring that is ingested from the UA.
+          type: array
+          items:
+            $ref: '#/components/schemas/OperationalIntentPositions'
+          default: [ ]
+    PositionRecord:
+      required:
+      - telemetry
+      - time_received
+      type: object
+      properties:
+        time_received:
+          description: Time that this position data was received by the USS
+          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
+        telemetry:
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/VehicleTelemetry'
+      description: A record of vehicle telemetry information received by this USS (typically for conformance monitoring).
+    OperationalIntentPositions:
+      required:
+      - operational_intent_id
+      type: object
+      properties:
+        positions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PositionRecord'
+          default: []
+        operational_intent_id:
+          description: ID of the operational intent associated with `positions`
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+      description: A record of position data gathered through the course of an operational intent
+    PlanningRecord:
+      required:
+      - ovns
+      - time
+      type: object
+      properties:
+        time:
+          description: Time that this planning event occurred
+          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
+        ovns:
+          type: array
+          description: OVNs the planning USS was aware of when it was planning the operational intent
+          items:
+            $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityOVN'
+          default: []
+        missing_operational_intents:
+          type: array
+          description: List of missing operational intents (for planning attempts that were denied by the DSS with code 409)
+          items:
+            $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+          default: []
+        missing_resources:
+          type: array
+          description: List of missing resources (for planning attempts that were denied by the DSS with code 409)
+          items:
+            $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+          default: []
+        operational_intent_id:
+          description: ID of the operational intent being planned
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+        problem:
+          type: string
+          description: A free text description of the problem(s) encountered during this planning attempt.
+      description: A record of a single attempt to (successfully or unsuccessfully) create or modify an operational intent.
+    UserNotificationRecord:
+      required:
+      - notification_time
+      - notification_triggering_event
+      - triggering_event_time
+      type: object
+      properties:
+        triggering_event_time:
+          description: Time of the notification triggering event
+          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
+        notification_time:
+          description: Time at which the user was notified
+          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
+        notification_details:
+          type: string
+          description: "Description of information that was provided to the user, as per the referenced notification_triggering_event requirement"
+        notification_triggering_event:
+          type: string
+          description: Requirement ID that pertains to the given notification
+          enum:
+          - GEN0400
+          - GEN0410
+          - ACM0020
+          - ACM0040
+      description: User notification record.
+    UserInputRecord:
+      required:
+      - input_triggering_event
+      - operational_intent_id
+      - triggering_event_time
+      type: object
+      properties:
+        triggering_event_time:
+          description: Time in which user input was received by the USS
+          $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
+        operational_intent_id:
+          description: ID of the operational_intent ID pertaining to the user input
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+        input_triggering_event:
+          type: string
+          description: Requirement ID that pertains to the given notification
+          enum:
+          - CM0030
+          - CM0040
+          - CM0045
+          - CM0035
+        input_details:
+          type: string
+          description: "Description of the information that was provided by the user, as per the referenced input_triggering_event requirement"
+      description: User input record
+    OperatorAssociation:
+      required:
+      - operational_intent_id
+      - operator_id
+      type: object
+      properties:
+        operational_intent_id:
+          description: ID of operational intent to which this association pertains
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityID'
+        operator_id:
+          type: string
+          description: Unique identifier of the operator responsible for the operational intent
+      description: Association between an operational intent and the operator of that operational intent


### PR DESCRIPTION
I just manually copied the changes into Chu Han's updated specs.  PlanningRecord looked like it was only used by this logging, so I moved it into OIM.   For the reporting, it seems like all the planning and notifications to other PSUs would be from OIM. Reporting positions could come from CM rather than OIM.  For now, I just put everything into OIM, but if you all think it makes more sense to put this into the shared area, I can move it.  Just let me know what you think. Thanks!