### PR TITLE
Schema and API cleanup after review - 3

### DIFF
--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -1018,7 +1018,16 @@ components:
           $ref: '#/components/schemas/RequiredAdditionalResources'
     IntentBasedImbalanceRecheckRequest:
       type: object
+      required:
+        - ovn
       properties:
+        ovn:
+          description: >-
+            The OVN (Opaque Version Number) of the operational intent being rechecked.
+            This value ensures that both the client and the DCB are referring to the same
+            version of the operational intent during imbalance evaluation, preventing
+            mismatches due to stale or conflicting state.
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/EntityOVN'
         required_additional_operations:
           $ref: '#/components/schemas/RequiredAdditionalOperations'
         required_additional_resources:

--- a/DSS/astm-uam-psu-dss-0.0.0.yaml
+++ b/DSS/astm-uam-psu-dss-0.0.0.yaml
@@ -1471,6 +1471,8 @@ components:
       description: "Specification of a geographic area that a client is interested in on an ongoing basis (e.g., \"planning area\")."
     QuerySubscriptionParameters:
       type: object
+      required:
+        - area_of_interest
       properties:
         area_of_interest:
           $ref: '#/components/schemas/Volume4D'
@@ -1927,6 +1929,8 @@ components:
       description: "Response to a request to create, update, or delete a ResourceReference. in the DSS."
     QueryResourceReferenceParameters:
       type: object
+      required:
+        - area_of_interest
       properties:
         area_of_interest:
           $ref: '#/components/schemas/Volume4D'


### PR DESCRIPTION
Here are minor changes we discussed during the meeting.

I also noticed that in the Volume4D schema, the `time_start` and `time_end` fields are not marked as required. If that's unintentional and they should be required, please let me know. I can make that adjustment and include it in this pull request.