### PR TITLE
Schema/API cleanup: trajectory & volume updates, Availability tag removal, point_designator added

### DIFF
--- a/CM/astm-uam-psu-cm-0.0.0.yaml
+++ b/CM/astm-uam-psu-cm-0.0.0.yaml
@@ -20,8 +20,6 @@ tags:
   description: Endpoints exposed by PSUs for peer-peer communication.
 - name: Reports
   description: Endpoints exposed by the PSUs for reporting peer PSU issues.
-- name: Availability
-  description: Endpoints exposed by the DSS for declaring USS availability.
 
 paths:
   /cm/v1/operational_intents:

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -955,6 +955,8 @@ components:
         - time
         - trajectory_property_array
       properties:
+        point_designator:
+          $ref: '../shared-components/schemas.yaml#/components/schemas/PointDesignator'
         lat_lng_point:
           description: "Latitude and Longitude of the point."
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/LatLngPoint'

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -29,8 +29,6 @@ tags:
     has availability.
 - name: Reports
   description: Endpoints exposed by the PSUs for reporting peer PSU issues.
-- name: Availability
-  description: Endpoints exposed by the DSS for declaring USS availability.
  
 paths:
   /dcb/v1/imbalance_subscriptions/{subscriptionid}:

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -953,6 +953,9 @@ components:
         - time
         - trajectory_point_property_array
       properties:
+        resource_id:
+          description: Identifier for the resource associated with this trajectory point.
+          $ref: '../shared-components/schemas.yaml#/components/schemas/UUIDv4Format'
         point_designator:
           $ref: '../shared-components/schemas.yaml#/components/schemas/PointDesignator'
         lat_lng_point:

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -951,7 +951,7 @@ components:
         - lat_lng_point
         - speed
         - time
-        - trajectory_property_array
+        - trajectory_point_property_array
       properties:
         point_designator:
           $ref: '../shared-components/schemas.yaml#/components/schemas/PointDesignator'
@@ -969,7 +969,7 @@ components:
             Speed of the vehicle at this TrajectoryPoint.
             FIXM allows for two speed entries:  predictedAirspeed and predictedGroundspeed
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/Velocity'
-        trajectory_property_array:
+        trajectory_point_property_array:
           maxItems: 4
           minItems: 1
           type: array
@@ -982,7 +982,7 @@ components:
           externalDocs:
             url: https://fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPoint4DType.html#Link2AC
           items:
-            $ref: '../OIM/astm-uam-psu-oim-0.0.0.yaml#/components/schemas/TrajectoryProperty'
+            $ref: '../OIM/astm-uam-psu-oim-0.0.0.yaml#/components/schemas/TrajectoryPointProperty'
     IntentTrajectory:
       type: object
       required:

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -23,8 +23,6 @@ tags:
 - name: Telemetry
 - name: Reports
   description: Endpoints exposed by the PSUs for reporting peer PSU issues.
-- name: Availability
-  description: Endpoints exposed by the DSS for declaring USS availability.
 - name: p2p_uam
   description: Endpoints exposed by PSUs for peer-peer communication.
 paths:

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -328,25 +328,43 @@ components:
 
   schemas:
     Trajectory:
-      maxItems: 1000
-      minItems: 2
-      type: array
-      description: |- 
-        The list of TrajectoryPoints for this operation.  This list must contain all significant TrajectoryPoints per the CBRs. 
-        Pre-flight, this list must contain all trajectory flights.  If updated during the flight, only the current trajectory
-        point to the destination should be included. 
-        For additional insight on points to be included, see the enumeration of property types in the TrajectoryPoint4D model."
-      items:
-        $ref: '#/components/schemas/TrajectoryPoint4D' 
+      type: object
+      description: Wrapper object for trajectory points of this operational intent.
+      properties:
+        trajectory:
+          type: array
+          minItems: 2
+          maxItems: 1000
+          description: |-
+            The list of TrajectoryPoints for this operation.  This list must contain 
+            all significant TrajectoryPoints per the CBRs. Pre-flight, this list must 
+            contain all trajectory flights.  If updated during the flight, only the 
+            current trajectory point to the destination should be included. 
+            For additional insight on points to be included, see the enumeration of 
+            property types in the TrajectoryPoint4D model.
+          items:
+            $ref: '#/components/schemas/TrajectoryPoint4D'
+          default: []
+      required:
+        - trajectory
+
     Volumes:
-      type: array
-      description: |-
-        Volumes that wholly contain the operational intent while being as small as practical.
-        Start and end times, as well as lower and upper altitudes, are required for each volume. The end time may not be in the past.
-        May not contain any items when the operational intent is Contingent.
-      items:
-        $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/Volume4D'
-      default: []   
+      type: object
+      description: Wrapper object for volume definitions of this operational intent.
+      properties:
+        volumes:
+          type: array
+          description: |-
+            Volumes that wholly contain the operational intent while being as small as 
+            practical. Start and end times, as well as lower and upper altitudes, are 
+            required for each volume. The end time may not be in the past.
+            May not contain any items when the operational intent is Contingent.
+          items:
+            $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/Volume4D'
+          default: []
+      required:
+        - volumes
+
     OperationalIntentDetails:
       required:
       - intent

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -462,7 +462,7 @@ components:
       - lat_lng_point
       - speed
       - time
-      - trajectory_property_array
+      - trajectory_point_property_array
       - resource_usage
       type: object
       properties:  
@@ -482,7 +482,7 @@ components:
             Speed of the vehicle at this TrajectoryPoint.
             FIXM allows for two speed entries:  predictedAirspeed and predictedGroundspeed
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/Velocity'
-        trajectory_property_array:
+        trajectory_point_property_array:
           maxItems: 4
           minItems: 1
           type: array
@@ -496,7 +496,7 @@ components:
           externalDocs:
             url: https://fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPoint4DType.html#Link2AC
           items:
-            $ref: '#/components/schemas/TrajectoryProperty'
+            $ref: '#/components/schemas/TrajectoryPointProperty'
         resource_usage:
           type: array
           description: If this trajectory point describes a resource crossing or entry/exit, the resource and the event type
@@ -514,7 +514,7 @@ components:
       externalDocs:
         description: See FIXM 4.2.0 for further information.
         url: https://www.fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPoint4DType.html#Link116
-    TrajectoryProperty:
+    TrajectoryPointProperty:
       required:
       - property_type
       type: object

--- a/OIM/astm-uam-psu-oim-0.0.0.yaml
+++ b/OIM/astm-uam-psu-oim-0.0.0.yaml
@@ -468,11 +468,8 @@ components:
       - resource_usage
       type: object
       properties:  
-        # TODO: Do we still need point_designator? Seems like this is replaced by the resource_id
-        # point_designator:
-        #   type: string
-        #   description: "The name of the designated point. This is required for all named airspace structure point from ASDS, including vertipads."
-        #   example: ee123
+        point_designator:
+          $ref: '../shared-components/schemas.yaml#/components/schemas/PointDesignator'        
         lat_lng_point:
           description: "Latitude and Longitude of the point. If this is for a named airspace structure point from ASDS, it should be the same value as from ASDS."
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/LatLngPoint'

--- a/RIS/astm-uam-psu-ris-0.0.0.yaml
+++ b/RIS/astm-uam-psu-ris-0.0.0.yaml
@@ -27,9 +27,6 @@ tags:
   description: Endpoints exposed by the RIS for details regarding the current status and capacity of a resource. 
 - name: Reports
   description: Endpoints exposed by the PSUs for reporting peer PSU issues.
-- name: Availability
-  description: Endpoints exposed by the DSS for declaring USS availability.
-
 
 paths:
   /ris/v1/resource_details/{entityid}:

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -188,6 +188,8 @@ components:
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
 
     PointDesignator:
+      maxLength: 30
+      minLength: 2
       description: Standardized identifier for this point (e.g., fix name or point-based resource code). 
         Optional for ad-hoc lat/long points; required when the point corresponds to a named fix or a point-based 
         resource. Use the published/canonical designator (e.g., DUNKK, DF100).

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -186,4 +186,11 @@ components:
       description: String whose format matches a version-4 UUID according to RFC 4122.
       format: uuid
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
+
+    PointDesignator:
+      description: Standardized identifier for this point (e.g., fix name or point-based resource code). 
+        Optional for ad-hoc lat/long points; required when the point corresponds to a named fix or a point-based 
+        resource. Use the published/canonical designator (e.g., DUNKK, DF100).
+      type: string
+      example: DF100
         

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -27,12 +27,12 @@ components:
         clientCredentials:
           tokenUrl: https://auth.example.com/oauth/token
           scopes:
-            utm.strategic_coordination: Client may perform actions encompassed by the strategic coordination role including strategic conflict detection.
-            utm.conformance_monitoring_sa: Client may perform actions encompassed by the conformance monitoring for situational awareness role.
+            utm.strategic_coordination: Client may perform strategic coordination actions encompassed by the OIM and DCB roles.
+            utm.conformance_monitoring_sa: Client may perform conformance monitoring actions encompassed by the CM role.
             utm.availability_arbitration: Client may set the availability state of PSUs in the DSS.
-            utm.resource_management:        to be provided  ---- !!!!!!!!
-            utm.resource_processing:        to be provided  ---- !!!!!!!!
-            utm.dcb_check:                  to be provided  ---- !!!!!!!!
+            utm.resource_management: Client may perform resource management actions encompassed by the RIS, resource operator and resource authority roles.
+            utm.resource_processing: Client may perform resource processing actions encompassed by the RIS role.
+            utm.dcb_check: Client may perform DCB check actions encompassed by the DCB role.
             
   schemas:
     ErrorReport:

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -190,9 +190,11 @@ components:
     PointDesignator:
       maxLength: 30
       minLength: 2
-      description: Standardized identifier for this point (e.g., fix name or point-based resource code). 
-        Optional for ad-hoc lat/long points; required when the point corresponds to a named fix or a point-based 
-        resource. Use the published/canonical designator (e.g., DUNKK, DF100).
+      description: |-
+        Standardized identifier for this point (e.g., fix name or point-based resource code).
+        Optional for ad-hoc lat/long points; required when the point corresponds to a named fix or a point-based resource.
+        Use the published/canonical designator (e.g., DUNKK, DF100).
+        When both `point_designator` and `lat_lng_point` are provided, **lat_lng_point is authoritative**.
       type: string
       example: DF100
-        
+      


### PR DESCRIPTION

1. Added `point_designator` field to `IntentTrajectoryPoint` and `TrajectoryPoint4D`
2. Removed `Availability` tag for non-DSS services
3. Renamed `TrajectoryProperty` schema to `TrajectoryPointProperty`
4. Updated `Trajectory` and `Volume` schemas to type object