### PR TITLE
Updates trajectory schema handling and resource availability API definitions.

### DIFF
--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -704,7 +704,6 @@ components:
         - lat_lng_point
         - speed
         - time
-        - trajectory_point_property_array
       properties:
         resource_id:
           description: Identifier for the resource associated with this trajectory point.
@@ -735,6 +734,7 @@ components:
             trajectory point. For X4 we are allowing up to 4.
             The first point of initial plan must include at a minimum: AIRPORT_REFERENCE_LOCATION, WHEELS_OFF
             The last point must include at a minimum: AIRPORT_REFERENCE_LOCATION, WHEELS_ON
+            This array may be omitted when no listed property applies to the point.
           externalDocs:
             url: https://fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPoint4DType.html#Link2AC
           items:

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -367,6 +367,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IntentBasedImbalanceRequest'
+        required: true
       responses:
         '200':
           description: >-
@@ -456,7 +457,8 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntentBasedImbalanceRecheckRequest'            
+              $ref: '#/components/schemas/IntentBasedImbalanceRecheckRequest'
+        required: true
       responses:
         '200':
           description: >-
@@ -535,6 +537,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AreaOrResourceBasedImbalanceRequest'
+        required: true
       responses:
         '200':
           description: >-

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -612,12 +612,14 @@ paths:
         - name: time_start
           in: query
           required: true
+          explode: false
           description: Parameter defining the start time for querying resource availability
           schema:
             $ref: '../shared-components/schemas.yaml#/components/schemas/Time'
         - name: time_end
           in: query
           required: true
+          explode: false
           description: Parameter defining the end time for querying resource availability
           schema:
             $ref: '../shared-components/schemas.yaml#/components/schemas/Time'

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -280,12 +280,11 @@ components:
       - lat_lng_point
       - speed
       - time
-      - trajectory_point_property_array
       - resource_usage
       type: object
-      properties:  
+      properties:
         point_designator:
-          $ref: '#/components/schemas/PointDesignator'        
+          $ref: '#/components/schemas/PointDesignator'
         lat_lng_point:
           description: "Latitude and Longitude of the point. If this is for a named airspace structure point from ASDS, it should be the same value as from ASDS."
           $ref: '#/components/schemas/LatLngPoint'
@@ -313,6 +312,7 @@ components:
             The first point of a pre-flight trajectory must include at a minimum: AIRPORT_REFERENCE_LOCATION, WHEELS_OFF.
             The last point must include at a minimum: AIRPORT_REFERENCE_LOCATION, WHEELS_ON.
             The time and location of the aircraft at the update can be included with the property: POINT_OF_INTENT_UPDATE.
+            This array may be omitted when no listed property applies to the point.
           externalDocs:
             url: https://fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPoint4DType.html#Link2AC
           items:
@@ -344,7 +344,8 @@ components:
           type: string
           description: |
             Provides the type of trajectory point property. Enum list is based on the FIXM definition
-            of TrajectoryPointPropertyType, but with some additions (i.e., POINT_OF_INTENT_UPDATE)
+            of TrajectoryPointPropertyType, but with some additions (i.e., POINT_OF_INTENT_UPDATE,
+            RESOURCE_INTERSECTION)
           externalDocs:
             description: FIXM definition of TrajectoryPointPropertyType
             url: https://fixm.aero/releases/FIXM-4.2.0/doc/schema_documentation/Fixm_TrajectoryPointPropertyType.html#Link2B0
@@ -358,6 +359,7 @@ components:
           - WHEELS_ON
           - AIRPORT_REFERENCE_LOCATION
           - POINT_OF_INTENT_UPDATE
+          - RESOURCE_INTERSECTION
       description: Describes any applicable properties of the trajectory point.
 
     Radius:
@@ -796,9 +798,9 @@ components:
       properties:
         resource_id:
           description: |-
-            The ID of the resource being referenced by the trajectory property array.
-            Required when crossing a waypoint-based resource or entering/exiting a 
-            volume-based resource. 
+            The ID of the resource associated with this trajectory point.
+            Required when crossing a waypoint-based resource or entering/exiting a
+            volume-based resource.
           $ref: '#/components/schemas/EntityID'
         resource_event:
           description: Describes if the trajectory point is a resource crossing or the beginning or end


### PR DESCRIPTION
- Makes trajectory point properties optional and adds a `RESOURCE_INTERSECTION` value to support DCB-inserted trajectory points.
- Sets resource availability time query parameters to non-exploded.
- Makes DCB request bodies required.
