### PR TITLE
Post review fixes 13

### DIFF
--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -910,7 +910,7 @@ components:
       type: object
       properties:
         uss_base_url:
-          description: "The base URL of a USS implementation of the parts of the USS-USS API necessary for receiving the notifications that the operational intent must be aware of.  This includes, at least, notifications for relevant changes in operational intents."
+          description: "The base URL of the OIM callback interface used by DCB to notify demand-capacity imbalances for monitored operational intents. DCB sends imbalance notifications by calling POST at `{uss_base_url}/imbalance`."
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/SubscriptionUssBaseURL'
         add_operational_intents:
           type: array
@@ -946,8 +946,9 @@ components:
           description: ID of the DCB monitoring subscription. 
         uss_base_url:
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/SubscriptionUssBaseURL'
-          description: Base URL which will be called when a DCB imbalance is detected for one 
-            of the operational intents monitored by this subscription. 
+          description: Base URL of the OIM callback interface which will be called at
+            `{uss_base_url}/imbalance` when a DCB imbalance is detected for one of the
+            operational intents monitored by this subscription.
         operational_intents_monitored:
           type: array
           description: List of IDs for operational intents that are monitored as part of this DCB. 

--- a/DCB/astm-uam-psu-dcb-0.0.0.yaml
+++ b/DCB/astm-uam-psu-dcb-0.0.0.yaml
@@ -906,6 +906,7 @@ components:
     CreateImbalanceSubscriptionParameters:
       required:
       - uss_base_url
+      - add_operational_intents
       type: object
       properties:
         uss_base_url:
@@ -913,10 +914,10 @@ components:
           $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/SubscriptionUssBaseURL'
         add_operational_intents:
           type: array
+          minItems: 1
           description: Operational intents to add for monitoring. 
           items:
             $ref: '#/components/schemas/OperationalIntentForMonitoring'
-          default: []
     OperationalIntentForMonitoring:
       required:
         - operational_intent_id

--- a/DSS/astm-uam-psu-dss-0.0.0.yaml
+++ b/DSS/astm-uam-psu-dss-0.0.0.yaml
@@ -1396,8 +1396,9 @@ components:
       description: >-
         The base URL of a USS implementation of the parts of the USS-USS API necessary for receiving 
         the notifications requested by this subscription. The base URL path pattern is '/{psu_role}/v1'.
-        The USS identified by this base URL must implement notification endpoints at `/resources` and
-        `/operational_intents` relative to this base URL. Notification senders construct the full
+        The USS identified by this base URL must implement the notification endpoints required by the
+        subscription type, such as `/resources`, `/operational_intents`, `/imbalance`, or
+        `/uss_availability` relative to this base URL. Notification senders construct the full
         notification URL by appending the appropriate path suffix to this base URL.
       type: string
       format: uri      

--- a/DSS/astm-uam-psu-dss-0.0.0.yaml
+++ b/DSS/astm-uam-psu-dss-0.0.0.yaml
@@ -1571,12 +1571,15 @@ components:
           description: "If an existing subscription is not specified in `subscription_id` and this field is populated, an implicit subscription will be created and associated with this resource, and will generally be deleted automatically upon the deletion of this resource."
           $ref: '#/components/schemas/ImplicitSubscriptionParameters'
         update_type:
-          type: string
-          description: The change that warrants notification of peers for the resource. 
-          enum:
-          - CAPACITY
-          - STATUS
-          - DEFINITION 
+          type: array
+          minItems: 1
+          description: One or more changes that warrant notification of peers for the resource.
+          items:
+            type: string
+            enum:
+            - CAPACITY
+            - STATUS
+            - DEFINITION
       description: Parameters for a request to create or update a ResourceReference in the DSS.
     GetResourceReferenceResponse:
       required:

--- a/shared-components/schemas.yaml
+++ b/shared-components/schemas.yaml
@@ -672,6 +672,13 @@ components:
           - WAYPOINT
           - VOLUME
 
+    ResourceDesignator:
+      maxLength: 30
+      minLength: 2
+      type: string
+      description: Short, stable, canonical designator/code used to identify a resource in operational communications, debugging, and review.
+      example: CHIPR
+
     ResourcePhysicalDefinition:
       required:
         - name
@@ -679,9 +686,11 @@ components:
         - type
       properties:
         name:
-            description: Name of the resource
-            example: CHIPR
-            $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/TextShortType'
+          description: Short, stable, canonical designator/code for the resource.
+          $ref: '#/components/schemas/ResourceDesignator'
+        description:
+          description: Free-text description of the resource.
+          $ref: '../DSS/astm-uam-psu-dss-0.0.0.yaml#/components/schemas/TextShortType'
         shape:
           $ref: '#/components/schemas/ResourceShape'
         altitude_lower:


### PR DESCRIPTION
Updates API review rows 78-81:

- Adds a canonical ResourceDesignator schema for resource names and separates free-text resource descriptions.
- Requires non-empty add_operational_intents when creating DCB imbalance subscriptions.
- Clarifies subscription callback base URL wording, including DCB imbalance callbacks at {uss_base_url}/imbalance.
- Allows DSS resource updates to specify multiple update_type values in one request.